### PR TITLE
Some minor changes / updates for compatibility with Voxgraph

### DIFF
--- a/cblox/include/cblox/core/submap_collection.h
+++ b/cblox/include/cblox/core/submap_collection.h
@@ -34,32 +34,32 @@ class SubmapCollection {
   // NOTE(alexmillane): T_G_S - Transformation between submap frame (S) and
   //                           the global tracking frame (G).
   // NOTE(alexmillane): Creating a new submap automatically makes it active.
-  void createNewSubMap(const Transformation &T_G_S, const SubmapID submap_id);
-  SubmapID createNewSubMap(const Transformation &T_G_S);
+  void createNewSubmap(const Transformation &T_G_S, const SubmapID submap_id);
+  SubmapID createNewSubmap(const Transformation &T_G_S);
 
   // Create a new submap which duplicates an existing source submap
-  bool duplicateSubMap(const SubmapID source_submap_id,
+  bool duplicateSubmap(const SubmapID source_submap_id,
                        const SubmapID new_submap_id);
 
   // Gets a const pointer to a raw submap
   // NOTE(alexmillane): This function hard fails when the submap doesn't
   // exist... This puts the onus on the caller to call exists() first. I don't
   // like this but I can't see a solution.
-  const SubmapType &getSubMap(const SubmapID submap_id) const;
+  const SubmapType &getSubmap(const SubmapID submap_id) const;
   // Note(alexmillane): Unlike the above method, the two methods below return a
   // nullptr when the map doesn't exist. No hard crash.
-  typename SubmapType::Ptr getSubMapPtr(const SubmapID submap_id);
-  typename SubmapType::ConstPtr getSubMapConstPtr(
+  typename SubmapType::Ptr getSubmapPtr(const SubmapID submap_id);
+  typename SubmapType::ConstPtr getSubmapConstPtr(
       const SubmapID submap_id) const;
   // A list of the submaps
-  const std::vector<typename SubmapType::Ptr> getSubMapPtrs() const;
-  const std::vector<typename SubmapType::ConstPtr> getSubMapConstPtrs() const;
+  const std::vector<typename SubmapType::Ptr> getSubmapPtrs() const;
+  const std::vector<typename SubmapType::ConstPtr> getSubmapConstPtrs() const;
 
   // Interactions with the active submap
-  const SubmapType &getActiveSubMap() const;
-  typename SubmapType::Ptr getActiveSubMapPtr();
-  const Transformation &getActiveSubMapPose() const;
-  const SubmapID getActiveSubMapID() const;
+  const SubmapType &getActiveSubmap() const;
+  typename SubmapType::Ptr getActiveSubmapPtr();
+  const Transformation &getActiveSubmapPose() const;
+  const SubmapID getActiveSubmapID() const;
 
   // Access the tsdf_map member of the active submap
   TsdfMap::Ptr getActiveTsdfMapPtr();
@@ -68,13 +68,13 @@ class SubmapCollection {
   // Activate a submap
   // NOTE(alexmillane): Note that creating a new submap automatically activates
   //                    it.
-  void activateSubMap(const SubmapID submap_id);
+  void activateSubmap(const SubmapID submap_id);
 
   // Interacting with the submap poses
-  bool setSubMapPose(const SubmapID submap_id, const Transformation &pose);
-  void setSubMapPoses(const TransformationVector &transforms);
-  bool getSubMapPose(const SubmapID submap_id, Transformation *pose_ptr) const;
-  void getSubMapPoses(TransformationVector* submap_poses) const;
+  bool setSubmapPose(const SubmapID submap_id, const Transformation &pose);
+  void setSubmapPoses(const TransformationVector &transforms);
+  bool getSubmapPose(const SubmapID submap_id, Transformation *pose_ptr) const;
+  void getSubmapPoses(TransformationVector *submap_poses) const;
 
   // Clears the collection, leaving an empty map
   void clear() { id_to_submap_.clear(); }

--- a/cblox/include/cblox/core/submap_collection.h
+++ b/cblox/include/cblox/core/submap_collection.h
@@ -46,9 +46,10 @@ class SubmapCollection {
   // exist... This puts the onus on the caller to call exists() first. I don't
   // like this but I can't see a solution.
   const SubmapType &getSubMap(const SubmapID submap_id) const;
-  // Note(alexmillane): Unlike the above this function returns a nullptr when
-  // the map doesn't exist. No hard crash.
-  typename SubmapType::ConstPtr getSubMapConstPtrById(
+  // Note(alexmillane): Unlike the above method, the two methods below return a
+  // nullptr when the map doesn't exist. No hard crash.
+  typename SubmapType::Ptr getSubMapPtr(const SubmapID submap_id);
+  typename SubmapType::ConstPtr getSubMapConstPtr(
       const SubmapID submap_id) const;
   // A list of the submaps
   const std::vector<typename SubmapType::Ptr> getSubMapPtrs() const;
@@ -65,7 +66,8 @@ class SubmapCollection {
   const TsdfMap &getActiveTsdfMap() const;
 
   // Activate a submap
-  // NOTE(alexmillane): Note that creating a new submap automatically activates it.
+  // NOTE(alexmillane): Note that creating a new submap automatically activates
+  //                    it.
   void activateSubMap(const SubmapID submap_id);
 
   // Interacting with the submap poses

--- a/cblox/include/cblox/core/submap_collection_inl.h
+++ b/cblox/include/cblox/core/submap_collection_inl.h
@@ -252,11 +252,22 @@ void SubmapCollection<SubmapType>::getSubMapPoses(
 }
 
 template <typename SubmapType>
-typename SubmapType::ConstPtr SubmapCollection<
-    SubmapType>::getSubMapConstPtrById(const SubmapID submap_id) const {
-  const auto tsdf_submap_ptr_it = id_to_submap_.find(submap_id);
-  if (tsdf_submap_ptr_it != id_to_submap_.end()) {
-    return tsdf_submap_ptr_it->second;
+typename SubmapType::Ptr SubmapCollection<SubmapType>::getSubMapPtr(
+    const SubmapID submap_id) {
+  const auto submap_ptr_it = id_to_submap_.find(submap_id);
+  if (submap_ptr_it != id_to_submap_.end()) {
+    return submap_ptr_it->second;
+  } else {
+    return typename SubmapType::Ptr();
+  }
+}
+
+template <typename SubmapType>
+typename SubmapType::ConstPtr SubmapCollection<SubmapType>::getSubMapConstPtr(
+    const SubmapID submap_id) const {
+  const auto submap_ptr_it = id_to_submap_.find(submap_id);
+  if (submap_ptr_it != id_to_submap_.end()) {
+    return submap_ptr_it->second;
   } else {
     return typename SubmapType::ConstPtr();
   }

--- a/cblox/include/cblox/core/submap_collection_inl.h
+++ b/cblox/include/cblox/core/submap_collection_inl.h
@@ -45,7 +45,7 @@ bool SubmapCollection<SubmapType>::exists(const SubmapID submap_id) const {
 }
 
 template <typename SubmapType>
-void SubmapCollection<SubmapType>::createNewSubMap(const Transformation& T_G_S,
+void SubmapCollection<SubmapType>::createNewSubmap(const Transformation& T_G_S,
                                                    const SubmapID submap_id) {
   // Checking if the submap already exists
   // NOTE(alexmillane): This hard fails the program if the submap already
@@ -63,7 +63,7 @@ void SubmapCollection<SubmapType>::createNewSubMap(const Transformation& T_G_S,
 }
 
 template <typename SubmapType>
-SubmapID SubmapCollection<SubmapType>::createNewSubMap(
+SubmapID SubmapCollection<SubmapType>::createNewSubmap(
     const Transformation& T_G_S) {
   // Creating a submap with a generated SubmapID
   // NOTE(alexmillane): rbegin() returns the pair with the highest key.
@@ -71,12 +71,12 @@ SubmapID SubmapCollection<SubmapType>::createNewSubMap(
   if (!id_to_submap_.empty()) {
     new_ID = id_to_submap_.rbegin()->first + 1;
   }
-  createNewSubMap(T_G_S, new_ID);
+  createNewSubmap(T_G_S, new_ID);
   return new_ID;
 }
 
 template <typename SubmapType>
-bool SubmapCollection<SubmapType>::duplicateSubMap(
+bool SubmapCollection<SubmapType>::duplicateSubmap(
     const SubmapID source_submap_id, const SubmapID new_submap_id) {
   // Get pointer to the source submap
   const auto src_submap_ptr_it = id_to_submap_.find(source_submap_id);
@@ -101,7 +101,7 @@ bool SubmapCollection<SubmapType>::duplicateSubMap(
 }
 
 template <typename SubmapType>
-const SubmapType& SubmapCollection<SubmapType>::getSubMap(
+const SubmapType& SubmapCollection<SubmapType>::getSubmap(
     const SubmapID submap_id) const {
   const auto it = id_to_submap_.find(submap_id);
   CHECK(it != id_to_submap_.end());
@@ -110,7 +110,7 @@ const SubmapType& SubmapCollection<SubmapType>::getSubMap(
 
 template <typename SubmapType>
 const std::vector<typename SubmapType::Ptr>
-SubmapCollection<SubmapType>::getSubMapPtrs() const {
+SubmapCollection<SubmapType>::getSubmapPtrs() const {
   std::vector<typename SubmapType::Ptr> submap_ptrs;
   for (const auto& id_submap_pair : id_to_submap_) {
     submap_ptrs.emplace_back(id_submap_pair.second);
@@ -120,7 +120,7 @@ SubmapCollection<SubmapType>::getSubMapPtrs() const {
 
 template <typename SubmapType>
 const std::vector<typename SubmapType::ConstPtr>
-SubmapCollection<SubmapType>::getSubMapConstPtrs() const {
+SubmapCollection<SubmapType>::getSubmapConstPtrs() const {
   std::vector<typename SubmapType::ConstPtr> submap_ptrs;
   for (const auto& id_submap_pair : id_to_submap_) {
     submap_ptrs.emplace_back(id_submap_pair.second);
@@ -142,7 +142,7 @@ const TsdfMap& SubmapCollection<SubmapType>::getActiveTsdfMap() const {
 }
 
 template <typename SubmapType>
-const SubmapType& SubmapCollection<SubmapType>::getActiveSubMap() const {
+const SubmapType& SubmapCollection<SubmapType>::getActiveSubmap() const {
   const auto it = id_to_submap_.find(active_submap_id_);
   CHECK(it != id_to_submap_.end());
   return *(it->second);
@@ -150,24 +150,24 @@ const SubmapType& SubmapCollection<SubmapType>::getActiveSubMap() const {
 
 // Gets a pointer to the active submap
 template <typename SubmapType>
-typename SubmapType::Ptr SubmapCollection<SubmapType>::getActiveSubMapPtr() {
+typename SubmapType::Ptr SubmapCollection<SubmapType>::getActiveSubmapPtr() {
   const auto it = id_to_submap_.find(active_submap_id_);
   CHECK(it != id_to_submap_.end());
   return it->second;
 }
 
 template <typename SubmapType>
-const Transformation& SubmapCollection<SubmapType>::getActiveSubMapPose()
+const Transformation& SubmapCollection<SubmapType>::getActiveSubmapPose()
     const {
-  return getActiveSubMap().getPose();
+  return getActiveSubmap().getPose();
 }
 template <typename SubmapType>
-const SubmapID SubmapCollection<SubmapType>::getActiveSubMapID() const {
+const SubmapID SubmapCollection<SubmapType>::getActiveSubmapID() const {
   return active_submap_id_;
 }
 
 template <typename SubmapType>
-void SubmapCollection<SubmapType>::activateSubMap(const SubmapID submap_id) {
+void SubmapCollection<SubmapType>::activateSubmap(const SubmapID submap_id) {
   const auto it = id_to_submap_.find(submap_id);
   CHECK(it != id_to_submap_.end());
   active_submap_id_ = submap_id;
@@ -194,7 +194,7 @@ TsdfMap::Ptr SubmapCollection<SubmapType>::getProjectedMap() const {
 }
 
 template <typename SubmapType>
-bool SubmapCollection<SubmapType>::setSubMapPose(const SubmapID submap_id,
+bool SubmapCollection<SubmapType>::setSubmapPose(const SubmapID submap_id,
                                                  const Transformation& pose) {
   // Looking for the submap
   const auto tsdf_submap_ptr_it = id_to_submap_.find(submap_id);
@@ -210,7 +210,7 @@ bool SubmapCollection<SubmapType>::setSubMapPose(const SubmapID submap_id,
 }
 
 template <typename SubmapType>
-void SubmapCollection<SubmapType>::setSubMapPoses(
+void SubmapCollection<SubmapType>::setSubmapPoses(
     const TransformationVector& transforms) {
   CHECK_EQ(transforms.size(), id_to_submap_.size());
   // NOTE(alexmillane): This assumes that the order of transforms matches the
@@ -224,7 +224,7 @@ void SubmapCollection<SubmapType>::setSubMapPoses(
 }
 
 template <typename SubmapType>
-bool SubmapCollection<SubmapType>::getSubMapPose(
+bool SubmapCollection<SubmapType>::getSubmapPose(
     const SubmapID submap_id, Transformation* pose_ptr) const {
   // Looking for the submap
   const auto tsdf_submap_ptr_it = id_to_submap_.find(submap_id);
@@ -240,7 +240,7 @@ bool SubmapCollection<SubmapType>::getSubMapPose(
 }
 
 template <typename SubmapType>
-void SubmapCollection<SubmapType>::getSubMapPoses(
+void SubmapCollection<SubmapType>::getSubmapPoses(
     AlignedVector<Transformation>* submap_poses_ptr) const {
   CHECK_NOTNULL(submap_poses_ptr);
   // Extracting transforms
@@ -252,7 +252,7 @@ void SubmapCollection<SubmapType>::getSubMapPoses(
 }
 
 template <typename SubmapType>
-typename SubmapType::Ptr SubmapCollection<SubmapType>::getSubMapPtr(
+typename SubmapType::Ptr SubmapCollection<SubmapType>::getSubmapPtr(
     const SubmapID submap_id) {
   const auto submap_ptr_it = id_to_submap_.find(submap_id);
   if (submap_ptr_it != id_to_submap_.end()) {
@@ -263,7 +263,7 @@ typename SubmapType::Ptr SubmapCollection<SubmapType>::getSubMapPtr(
 }
 
 template <typename SubmapType>
-typename SubmapType::ConstPtr SubmapCollection<SubmapType>::getSubMapConstPtr(
+typename SubmapType::ConstPtr SubmapCollection<SubmapType>::getSubmapConstPtr(
     const SubmapID submap_id) const {
   const auto submap_ptr_it = id_to_submap_.find(submap_id);
   if (submap_ptr_it != id_to_submap_.end()) {

--- a/cblox/include/cblox/core/tsdf_esdf_submap.h
+++ b/cblox/include/cblox/core/tsdf_esdf_submap.h
@@ -46,7 +46,7 @@ class TsdfEsdfSubmap : public TsdfSubmap {
    *       saveToStream() methods from tsdf_submap.
    */
 
- private:
+ protected:
   EsdfMap::Ptr esdf_map_;
   voxblox::EsdfIntegrator::Config esdf_integrator_config_;
 };

--- a/cblox/include/cblox/io/tsdf_submap_io_inl.h
+++ b/cblox/include/cblox/io/tsdf_submap_io_inl.h
@@ -47,7 +47,7 @@ bool LoadSubmapFromStream(
             << q.x() << ", " << q.y() << ", " << q.z() << " ]";
 
   // Creating a new submap to hold the data
-  tsdf_submap_collection_ptr->createNewSubMap(T_M_S, tsdf_sub_map_proto.id());
+  tsdf_submap_collection_ptr->createNewSubmap(T_M_S, tsdf_sub_map_proto.id());
 
   // Getting the blocks for this submap (the tsdf layer)
   if (!voxblox::io::LoadBlocksFromStream(

--- a/cblox/include/cblox/mesh/submap_mesher_inl.h
+++ b/cblox/include/cblox/mesh/submap_mesher_inl.h
@@ -11,7 +11,7 @@ void SubmapMesher::generateSeparatedMesh(
   CHECK_NOTNULL(seperated_mesh_layer_ptr);
   // Getting the submaps
   const std::vector<typename SubmapType::ConstPtr> sub_maps =
-      submap_collection.getSubMapConstPtrs();
+      submap_collection.getSubmapConstPtrs();
   // Generating the mesh layers
   std::vector<MeshLayer::Ptr> sub_map_mesh_layers;
   generateSeparatedMeshLayers<SubmapType>(sub_maps, &sub_map_mesh_layers);
@@ -19,7 +19,7 @@ void SubmapMesher::generateSeparatedMesh(
   colorMeshLayersWithIndex(&sub_map_mesh_layers);
   // Get submap transforms
   AlignedVector<Transformation> sub_map_poses;
-  submap_collection.getSubMapPoses(&sub_map_poses);
+  submap_collection.getSubmapPoses(&sub_map_poses);
   // Combining the mesh layers
   // NOTE(alexmillane): Have to construct a vector of pointers to const...
   combineMeshLayers(std::vector<MeshLayer::ConstPtr>(

--- a/cblox/src/integrator/tsdf_submap_collection_integrator.cpp
+++ b/cblox/src/integrator/tsdf_submap_collection_integrator.cpp
@@ -26,7 +26,7 @@ void TsdfSubmapCollectionIntegrator::switchToActiveSubmap() {
   //                    integrator wont be affecting the latest submap in the
   //                    collection.
   updateIntegratorTarget(tsdf_submap_collection_ptr_->getActiveTsdfMapPtr());
-  T_G_S_active_ = tsdf_submap_collection_ptr_->getActiveSubMapPose();
+  T_G_S_active_ = tsdf_submap_collection_ptr_->getActiveSubmapPose();
 }
 
 void TsdfSubmapCollectionIntegrator::initializeIntegrator(

--- a/cblox/src/mesh/submap_mesher.cpp
+++ b/cblox/src/mesh/submap_mesher.cpp
@@ -17,7 +17,7 @@ void SubmapMesher::generatePatchMeshes(
   CHECK_NOTNULL(sub_map_mesh_layers_ptr);
   // Getting the submaps
   const std::vector<TsdfSubmap::ConstPtr> tsdf_sub_maps =
-      tsdf_submap_collection.getSubMapConstPtrs();
+      tsdf_submap_collection.getSubmapConstPtrs();
   // Generating the mesh layers
   generateSeparatedMeshLayers<TsdfSubmap>(tsdf_sub_maps,
                                           sub_map_mesh_layers_ptr);

--- a/cblox/src/mesh/submap_mesher.cpp
+++ b/cblox/src/mesh/submap_mesher.cpp
@@ -85,8 +85,8 @@ void SubmapMesher::colorMeshLayersWithIndex(
     // Extracting the mesh layer
     MeshLayer* mesh_layer_ptr = ((*sub_map_mesh_layers)[sub_map_index]).get();
     // Generating a color
-    double color_map_index = static_cast<double>(sub_map_index) /
-                             static_cast<double>(num_sub_maps - 1);
+    double color_map_index =
+        static_cast<double>(sub_map_index) / static_cast<double>(num_sub_maps);
     Color sub_map_color = voxblox::rainbowColorMap(color_map_index);
     // Coloring this mesh layer
     colorMeshLayer(sub_map_color, mesh_layer_ptr);

--- a/cblox_ros/include/cblox_ros/tsdf_submap_server.h
+++ b/cblox_ros/include/cblox_ros/tsdf_submap_server.h
@@ -65,7 +65,7 @@ class TsdfSubmapServer {
   void visualizeWholeMap();
 
   // Visualize trajectory
-  void visualizeSubMapBaseframes() const;
+  void visualizeSubmapBaseframes() const;
   void visualizeTrajectory() const;
 
   // Mesh output
@@ -107,8 +107,7 @@ class TsdfSubmapServer {
 
   // Submap creation
   bool newSubmapRequired() const;
-  void createNewSubMap(const Transformation& T_G_C);
-
+  void createNewSubmap(const Transformation& T_G_C);
 
   // Node handles
   ros::NodeHandle nh_;

--- a/cblox_ros/src/active_submap_visualizer.cc
+++ b/cblox_ros/src/active_submap_visualizer.cc
@@ -7,7 +7,7 @@ namespace cblox {
 void ActiveSubmapVisualizer::switchToActiveSubmap() {
   CHECK(tsdf_submap_collection_ptr_);
   // Getting the active submap ID
-  const SubmapID submap_id = tsdf_submap_collection_ptr_->getActiveSubMapID();
+  const SubmapID submap_id = tsdf_submap_collection_ptr_->getActiveSubmapID();
   if (mesh_layers_.find(submap_id) == mesh_layers_.end()) {
     ROS_INFO_STREAM("Creating mesh layer for submap id: " << submap_id);
     createMeshLayer();
@@ -26,7 +26,7 @@ void ActiveSubmapVisualizer::createMeshLayer() {
       new voxblox::MeshLayer(tsdf_submap_collection_ptr_->block_size()));
   active_submap_color_idx_ = current_color_idx_;
   // Saving mesh layer and color for later recovery
-  const SubmapID submap_id = tsdf_submap_collection_ptr_->getActiveSubMapID();
+  const SubmapID submap_id = tsdf_submap_collection_ptr_->getActiveSubmapID();
   mesh_layers_[submap_id] = active_submap_mesh_layer_ptr_;
   mesh_color_indices_[submap_id] = active_submap_color_idx_;
   // Updating the color index for the next map.
@@ -34,7 +34,7 @@ void ActiveSubmapVisualizer::createMeshLayer() {
 }
 
 void ActiveSubmapVisualizer::recoverMeshLayer() {
-  const SubmapID submap_id = tsdf_submap_collection_ptr_->getActiveSubMapID();
+  const SubmapID submap_id = tsdf_submap_collection_ptr_->getActiveSubmapID();
   auto mesh_it = mesh_layers_.find(submap_id);
   auto color_it = mesh_color_indices_.find(submap_id);
   CHECK(mesh_it != mesh_layers_.end())
@@ -69,7 +69,7 @@ void ActiveSubmapVisualizer::transformMeshLayerToGlobalFrame(
   CHECK_NOTNULL(mesh_layer_G_ptr);
   // Transforming all triangles in the mesh and adding to the combined layer
   const Transformation& T_G_S =
-      tsdf_submap_collection_ptr_->getActiveSubMapPose();
+      tsdf_submap_collection_ptr_->getActiveSubmapPose();
   SubmapMesher::transformAndAddTrianglesToLayer(mesh_layer_S, T_G_S,
                                                 mesh_layer_G_ptr);
 }
@@ -103,7 +103,7 @@ void ActiveSubmapVisualizer::getDisplayMesh(
   // Filling the marker
   const voxblox::ColorMode color_mode = voxblox::ColorMode::kLambertColor;
   voxblox::fillMarkerWithMesh(mesh_layer_ptr, color_mode, marker_ptr);
-  marker_ptr->id = tsdf_submap_collection_ptr_->getActiveSubMapID();
+  marker_ptr->id = tsdf_submap_collection_ptr_->getActiveSubmapID();
 }
 
 }  // namespace cblox

--- a/cblox_ros/src/tsdf_submap_server.cc
+++ b/cblox_ros/src/tsdf_submap_server.cc
@@ -156,7 +156,7 @@ void TsdfSubmapServer::servicePointcloudQueue() {
                                       is_freespace_pointcloud);
 
     if (newSubmapRequired()) {
-      createNewSubMap(T_G_C);
+      createNewSubmap(T_G_C);
     }
 
     trajectory_visualizer_ptr_->addPose(T_G_C);
@@ -246,7 +246,7 @@ void TsdfSubmapServer::integratePointcloud(const Transformation& T_G_C,
 
 void TsdfSubmapServer::intializeMap(const Transformation& T_G_C) {
   // Just creates the first submap
-  createNewSubMap(T_G_C);
+  createNewSubmap(T_G_C);
 }
 
 bool TsdfSubmapServer::newSubmapRequired() const {
@@ -254,10 +254,10 @@ bool TsdfSubmapServer::newSubmapRequired() const {
           num_integrated_frames_per_submap_);
 }
 
-void TsdfSubmapServer::createNewSubMap(const Transformation& T_G_C) {
+void TsdfSubmapServer::createNewSubmap(const Transformation& T_G_C) {
   // Creating the submap
   const SubmapID submap_id =
-      tsdf_submap_collection_ptr_->createNewSubMap(T_G_C);
+      tsdf_submap_collection_ptr_->createNewSubmap(T_G_C);
   // Activating the submap in the frame integrator
   tsdf_submap_collection_integrator_ptr_->switchToActiveSubmap();
   // Resetting current submap counters
@@ -267,7 +267,7 @@ void TsdfSubmapServer::createNewSubMap(const Transformation& T_G_C) {
   active_submap_visualizer_ptr_->switchToActiveSubmap();
 
   // Publish the baseframes
-  visualizeSubMapBaseframes();
+  visualizeSubmapBaseframes();
 
   if (verbose_) {
     ROS_INFO_STREAM("Created a new submap with id: "
@@ -292,7 +292,7 @@ void TsdfSubmapServer::visualizeActiveSubmapMesh() {
 void TsdfSubmapServer::visualizeWholeMap() {
   // Looping through the whole map, meshing and publishing.
   for (const SubmapID submap_id : tsdf_submap_collection_ptr_->getIDs()) {
-    tsdf_submap_collection_ptr_->activateSubMap(submap_id);
+    tsdf_submap_collection_ptr_->activateSubmap(submap_id);
     active_submap_visualizer_ptr_->switchToActiveSubmap();
     visualizeActiveSubmapMesh();
   }
@@ -350,10 +350,10 @@ void TsdfSubmapServer::updateMeshEvent(const ros::TimerEvent& /*event*/) {
   }
 }
 
-void TsdfSubmapServer::visualizeSubMapBaseframes() const {
+void TsdfSubmapServer::visualizeSubmapBaseframes() const {
   // Get poses
   TransformationVector submap_poses;
-  tsdf_submap_collection_ptr_->getSubMapPoses(&submap_poses);
+  tsdf_submap_collection_ptr_->getSubmapPoses(&submap_poses);
   // Transform to message
   geometry_msgs::PoseArray pose_array_msg;
   posesToMsg(submap_poses, &pose_array_msg);


### PR DESCRIPTION
This introduces two small changes
- The first and last submap used to get the same color, since 0.0 and 1.0 in voxblox::rainbowColorMap(...) map to the same color (i.e. its a color wheel). If we divide the submap_index (starting at 0) by num_sub_maps, the highest ratio would remain smaller than one.
- The private members of TsdfEsdfSubmap are now protected, such that the derived Submap class in Voxgraph can access them.
- As discussed in https://github.com/ethz-asl/c-blox/pull/4#discussion_r272809758, I added a method to get non-const pointers to submaps.
- To keep the naming consistent with the original method const SubmapType &getSubMap(...), I renamed getSubMapPtrById(...) and getSubMapConstPtrById(...) to getSubMapPtr(...) and getSubMapConstPtr(...). Hopefully this doesn't this doesn't require too many code changes from other users of cblox. @gasserl, please let me know if this is annoying for you. For consistency it seemed better to update it now than never, but we could also not change this. @alexmillane, what would you prefer?