### PR TITLE
Segfault from Eigen flag mismatch

### DIFF
--- a/cblox/CMakeLists.txt
+++ b/cblox/CMakeLists.txt
@@ -9,9 +9,6 @@ catkin_simple(ALL_DEPS_REQUIRED)
 # Mark these as system deps to supress warnings.
 include_directories(SYSTEM ${catkin_INCLUDE_DIRS})
 
-find_package(Eigen3 REQUIRED)
-include_directories(${Eigen_INCLUDE_DIRS})
-
 ############
 # PROTOBUF #
 ############

--- a/cblox/CMakeLists.txt
+++ b/cblox/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.0)
 project(cblox)
 
-add_definitions(-std=c++11 -march=native)
+add_definitions(-std=c++11)
 
 find_package(catkin_simple REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)

--- a/cblox/package.xml
+++ b/cblox/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>catkin_simple</buildtool_depend>
 
   <!-- Dependencies. -->
+  <depend>eigen_catkin</depend>
   <depend>glog_catkin</depend>
   <depend>voxblox</depend>
   <depend>minkindr</depend>


### PR DESCRIPTION
This fix hopefully resolves the segfaults some users have been experiencing. It works on my pc, but it would be great if others could test and confirm.

The main change is to remove the `-march=native` flag, which enables all Eigen optimization flags for the current architecture. This causes segfaults when it is used inconsistently, in this case in combination with the [voxblox](https://github.com/ethz-asl/voxblox) packages that is compiled without special Eigen flags.

A further change was to remove the explicit dependency on system's Eigen. This makes things cleaner, but the change is optional. Let me know if you agree @alexmillane :)