### PR TITLE
Added getMemorySize() to submap collection.

### DIFF
--- a/cblox/include/cblox/core/submap_collection.h
+++ b/cblox/include/cblox/core/submap_collection.h
@@ -103,6 +103,9 @@ class SubmapCollection {
   // Flattens the collection map down to a normal TSDF map
   TsdfMap::Ptr getProjectedMap() const;
 
+  // Gets the combined memory size of the layers in this collection.
+  size_t getMemorySize() const;
+
  private:
   // TODO(alexmillane): Get some concurrency guards
 

--- a/cblox/include/cblox/core/submap_collection_inl.h
+++ b/cblox/include/cblox/core/submap_collection_inl.h
@@ -364,6 +364,16 @@ size_t SubmapCollection<SubmapType>::getNumberAllocatedBlocks() const {
   return total_blocks;
 }
 
+template <typename SubmapType>
+size_t SubmapCollection<SubmapType>::getMemorySize() const {
+  // Looping over the submaps totalling the sizes
+  size_t size = 0u;
+  for (const auto& id_submap_pair : id_to_submap_) {
+    size += (id_submap_pair.second)->getMemorySize();
+  }
+  return size;
+}
+
 }  // namespace cblox
 
 #endif  // CBLOX_CORE_SUBMAP_COLLECTION_INL_H_

--- a/cblox/include/cblox/core/tsdf_submap.h
+++ b/cblox/include/cblox/core/tsdf_submap.h
@@ -58,6 +58,10 @@ class TsdfSubmap {
     return tsdf_map_->getTsdfLayer().getNumberOfAllocatedBlocks();
   }
 
+  size_t getMemorySize() const {
+    return tsdf_map_->getTsdfLayer().getMemorySize();
+  }
+
   // Getting the proto for this submap
   void getProto(TsdfSubmapProto* proto) const;
 


### PR DESCRIPTION
Useful for inspecting the size of things when you start running out of memory :s.

Note that this is an approximation, I have include only the sizes of the layers. In all but tiny maps this will be the vast majority of memory use.