### PR TITLE
Fix/submap ids in vector constructor

### DIFF
--- a/cblox/CMakeLists.txt
+++ b/cblox/CMakeLists.txt
@@ -24,7 +24,11 @@ PROTOBUF_CATKIN_GENERATE_CPP2(${BASE_PATH} PROTO_SRCS PROTO_HDRS ${PROTO_DEFNS})
 #############
 # LIBRARIES #
 #############
-cs_add_library(cblox_lib
+cs_add_library(${PROJECT_NAME}_proto
+  ${PROTO_SRCS}
+)
+
+cs_add_library(${PROJECT_NAME}_lib
   src/core/tsdf_submap.cpp
   src/core/tsdf_esdf_submap.cpp
   src/integrator/tsdf_submap_collection_integrator.cpp
@@ -32,13 +36,11 @@ cs_add_library(cblox_lib
   src/mesh/submap_mesher.cpp
   src/io/tsdf_submap_io.cpp
   src/io/transformation_io.cpp
-  ${PROTO_SRCS}
 )
-target_link_libraries(cblox_lib ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME}_lib ${PROJECT_NAME}_proto)
 
 ##########
 # EXPORT #
 ##########
-
 cs_install()
-cs_export()
+cs_export(INCLUDE_DIRS ${CATKIN_DEVEL_PREFIX}/include)

--- a/cblox/include/cblox/core/submap_collection_inl.h
+++ b/cblox/include/cblox/core/submap_collection_inl.h
@@ -19,11 +19,12 @@ SubmapCollection<SubmapType>::SubmapCollection(
     const std::vector<typename SubmapType::Ptr>& tsdf_sub_maps)
     : submap_config_(submap_config) {
   // Constructing from a list of existing submaps
-  // NOTE(alexmillane): assigning arbitrary SubmapIDs
-  SubmapID submap_id = 0;
+  // NOTE(alexmillane): Relies on the submaps having unique submap IDs...
   for (const auto& tsdf_submap_ptr : tsdf_sub_maps) {
-    id_to_submap_[submap_id] = tsdf_submap_ptr;
-    submap_id++;
+    const auto ret =
+        id_to_submap_.insert({tsdf_submap_ptr->getID(), tsdf_submap_ptr});
+    CHECK(ret.second) << "Attempted to construct collection from vector of "
+                         "submaps containing at least one duplicate ID.";
   }
 }
 


### PR DESCRIPTION
Before I was assigning ascending IDs in the collection-from-vector constructor regardless of the IDs contained in the submaps. I have changed this now.

We now rely on the user to have non-duplicate submap ids within the submaps, and the code fail if this isn't the case, however, I think that this is a reasonable expectation.