### PR TITLE
Updated to return by value

### DIFF
--- a/cblox/include/cblox/core/submap_collection_inl.h
+++ b/cblox/include/cblox/core/submap_collection_inl.h
@@ -366,10 +366,9 @@ bool SubmapCollection<SubmapType>::LoadFromFile(
        sub_map_index < submap_collection_proto.num_submaps(); ++sub_map_index) {
     LOG(INFO) << "Loading submap number: " << sub_map_index;
     // Loading the submaps
-    typename SubmapType::Ptr submap_ptr;
-    if (!SubmapType::LoadFromStream((*submap_collection_ptr)->getConfig(),
-                                    &proto_file, &tmp_byte_offset,
-                                    &submap_ptr)) {
+    typename SubmapType::Ptr submap_ptr = SubmapType::LoadFromStream(
+        (*submap_collection_ptr)->getConfig(), &proto_file, &tmp_byte_offset);
+    if (submap_ptr == nullptr) {
       LOG(ERROR) << "Could not load the submap from stream.";
       return false;
     }

--- a/cblox/include/cblox/core/tsdf_esdf_submap.h
+++ b/cblox/include/cblox/core/tsdf_esdf_submap.h
@@ -62,9 +62,10 @@ class TsdfEsdfSubmap : public TsdfSubmap {
   virtual bool saveToStream(std::fstream* outfile_ptr) const;
 
   // Load a submap from stream.
-  static bool LoadFromStream(const Config& config, std::fstream* proto_file_ptr,
-                             uint64_t* tmp_byte_offset_ptr,
-                             TsdfEsdfSubmap::Ptr* submap_ptr);
+  // Note(alexmillane): Returns a nullptr if load is unsuccessful.
+  static TsdfEsdfSubmap::Ptr LoadFromStream(const Config& config,
+                                            std::fstream* proto_file_ptr,
+                                            uint64_t* tmp_byte_offset_ptr);
 
  protected:
   Config config_;

--- a/cblox/include/cblox/core/tsdf_submap.h
+++ b/cblox/include/cblox/core/tsdf_submap.h
@@ -81,9 +81,10 @@ class TsdfSubmap {
   virtual bool saveToStream(std::fstream* outfile_ptr) const;
 
   // Load a submap from stream.
-  static bool LoadFromStream(const Config& config, std::fstream* proto_file_ptr,
-                             uint64_t* tmp_byte_offset_ptr,
-                             TsdfSubmap::Ptr* submap_ptr);
+  // Note(alexmillane): Returns a nullptr if load is unsuccessful.
+  static TsdfSubmap::Ptr LoadFromStream(const Config& config,
+                                        std::fstream* proto_file_ptr,
+                                        uint64_t* tmp_byte_offset_ptr);
 
  protected:
   SubmapID submap_id_;


### PR DESCRIPTION
The current way of loading submaps was causing horrible syntax in voxgraph. I'm not a fan of returning nullptrs but this is looking like the best option to me at this point. 