### PR TITLE
Add base submap class

### DIFF
--- a/cblox/include/cblox/core/submap.h
+++ b/cblox/include/cblox/core/submap.h
@@ -4,7 +4,6 @@
 #include <fstream>
 #include <mutex>
 
-#include "cblox/Submap.pb.h"
 #include "cblox/core/common.h"
 
 namespace cblox {

--- a/cblox/include/cblox/core/submap.h
+++ b/cblox/include/cblox/core/submap.h
@@ -39,8 +39,24 @@ class Submap {
 
   virtual void prepareForPublish() = 0;
 
+  /*
+  // Note(ntonci): In order to provide saving/loading functionality to the
+  // derived class, the following methods should be implemented (see TsdfSubmap
+  // as an example):
+
+  // Getting the proto for this submap.
+  virtual void getProto(SubmapProto* proto) const = 0;
+  // Save the submap to file.
+  virtual bool saveToStream(std::fstream* outfile_ptr) const;
+  // Load a submap from stream.
+  // Note(alexmillane): Returns a nullptr if load is unsuccessful.
+  static Submap::Ptr LoadFromStream(const Config& config,
+                                    std::fstream* proto_file_ptr,
+                                    uint64_t* tmp_byte_offset_ptr);
+  */
+
  protected:
-  SubmapID submap_id_;
+  const SubmapID submap_id_;
   Transformation T_M_S_;
 
  private:

--- a/cblox/include/cblox/core/submap.h
+++ b/cblox/include/cblox/core/submap.h
@@ -1,0 +1,54 @@
+#ifndef CBLOX_CORE_SUBMAP_H_
+#define CBLOX_CORE_SUBMAP_H_
+
+#include <fstream>
+#include <mutex>
+
+#include "cblox/Submap.pb.h"
+#include "cblox/core/common.h"
+
+namespace cblox {
+
+// Pure virtual class representing a submap.
+class Submap {
+ public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  // Constructor.
+  Submap(const Transformation& T_M_S, SubmapID submap_id)
+      : submap_id_(submap_id), T_M_S_(T_M_S) {}
+
+  ~Submap() {}
+
+  // Submap pose interaction.
+  inline const Transformation& getPose() const {
+    std::unique_lock<std::mutex> lock(transformation_mutex_);
+    return T_M_S_;
+  }
+
+  inline void setPose(const Transformation& T_M_S) {
+    std::unique_lock<std::mutex> lock(transformation_mutex_);
+    T_M_S_ = T_M_S;
+  }
+
+  inline SubmapID getID() const { return submap_id_; }
+
+  virtual size_t getNumberAllocatedBlocks() const = 0;
+
+  virtual size_t getMemorySize() const = 0;
+
+  virtual void finishSubmap() = 0;
+
+  virtual void prepareForPublish() = 0;
+
+ protected:
+  SubmapID submap_id_;
+  Transformation T_M_S_;
+
+ private:
+  mutable std::mutex transformation_mutex_;
+};
+
+}  // namespace cblox
+
+#endif  // CBLOX_CORE_SUBMAP_H_

--- a/cblox/include/cblox/core/submap.h
+++ b/cblox/include/cblox/core/submap.h
@@ -1,7 +1,6 @@
 #ifndef CBLOX_CORE_SUBMAP_H_
 #define CBLOX_CORE_SUBMAP_H_
 
-#include <fstream>
 #include <mutex>
 
 #include "cblox/core/common.h"

--- a/cblox/include/cblox/core/tsdf_esdf_submap.h
+++ b/cblox/include/cblox/core/tsdf_esdf_submap.h
@@ -11,6 +11,8 @@ namespace cblox {
 
 class TsdfEsdfSubmap : public TsdfSubmap {
  public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
   typedef std::shared_ptr<TsdfEsdfSubmap> Ptr;
   typedef std::shared_ptr<const TsdfEsdfSubmap> ConstPtr;
 
@@ -23,6 +25,7 @@ class TsdfEsdfSubmap : public TsdfSubmap {
         : TsdfSubmap::Config(tsdf_map_config),
           EsdfMap::Config(esdf_map_config){};
   };
+
   TsdfEsdfSubmap(const Transformation& T_M_S, SubmapID submap_id, Config config,
                  voxblox::EsdfIntegrator::Config esdf_integrator_config =
                      voxblox::EsdfIntegrator::Config())
@@ -41,24 +44,19 @@ class TsdfEsdfSubmap : public TsdfSubmap {
     }
   }
 
-  // Generate the ESDF from the TSDF
+  // Generate the ESDF from the TSDF.
   void generateEsdf();
 
   // Returns the underlying ESDF map pointers
   EsdfMap::Ptr getEsdfMapPtr() { return esdf_map_; }
   const EsdfMap& getEsdfMap() const { return *esdf_map_; }
 
-  /* NOTE: When converting TsdfEsdf submaps into protobuffs, only their
-   *       TSDF map is converted. The ESDF can be recomputed when needed.
-   *       If you'd like to also store the ESDF, override the getProto() and
-   *       saveToStream() methods from tsdf_submap.
-   */
-
   virtual void finishSubmap() override;
 
   virtual void prepareForPublish() override;
 
   virtual void getProto(cblox::SubmapProto* proto) const;
+
   virtual bool saveToStream(std::fstream* outfile_ptr) const;
 
   // Load a submap from stream.
@@ -72,6 +70,7 @@ class TsdfEsdfSubmap : public TsdfSubmap {
   EsdfMap::Ptr esdf_map_;
   voxblox::EsdfIntegrator::Config esdf_integrator_config_;
 };
+
 }  // namespace cblox
 
 #endif  // CBLOX_CORE_TSDF_ESDF_SUBMAP_H_

--- a/cblox/src/core/tsdf_esdf_submap.cpp
+++ b/cblox/src/core/tsdf_esdf_submap.cpp
@@ -4,11 +4,11 @@
 namespace cblox {
 
 void TsdfEsdfSubmap::generateEsdf() {
-  // Instantiate the integrator
+  // Instantiate the integrator.
   voxblox::EsdfIntegrator esdf_integrator(esdf_integrator_config_,
                                           tsdf_map_->getTsdfLayerPtr(),
                                           esdf_map_->getEsdfLayerPtr());
-  // Generate the ESDF
+  // Generate the ESDF.
   LOG(INFO) << "Generating ESDF from TSDF for submap with ID: " << submap_id_;
   esdf_integrator.updateFromTsdfLayerBatch();
 }
@@ -21,7 +21,7 @@ void TsdfEsdfSubmap::getProto(cblox::SubmapProto* proto) const {
   CHECK_NOTNULL(proto);
   TsdfSubmap::getProto(proto);
 
-  // add ESDF info
+  // Add ESDF info.
   size_t num_blocks = esdf_map_->getEsdfLayer().getNumberOfAllocatedBlocks();
   proto->set_num_esdf_blocks(num_blocks);
 }
@@ -33,7 +33,7 @@ bool TsdfEsdfSubmap::saveToStream(std::fstream* outfile_ptr) const {
     return false;
   }
 
-  // Saving ESDF layer
+  // Saving ESDF layer.
   constexpr bool kIncludeAllBlocks = true;
   const Layer<EsdfVoxel>& esdf_layer = esdf_map_->getEsdfLayer();
   if (!esdf_layer.saveBlocksToStream(kIncludeAllBlocks,
@@ -43,7 +43,7 @@ bool TsdfEsdfSubmap::saveToStream(std::fstream* outfile_ptr) const {
     return false;
   }
 
-  // Success
+  // Success.
   return true;
 }
 
@@ -53,7 +53,7 @@ TsdfEsdfSubmap::Ptr TsdfEsdfSubmap::LoadFromStream(
   CHECK_NOTNULL(proto_file_ptr);
   CHECK_NOTNULL(tmp_byte_offset_ptr);
 
-  // Getting the header for this submap
+  // Getting the header for this submap.
   SubmapProto submap_proto;
   if (!voxblox::utils::readProtoMsgFromStream(proto_file_ptr, &submap_proto,
                                               tmp_byte_offset_ptr)) {
@@ -61,7 +61,7 @@ TsdfEsdfSubmap::Ptr TsdfEsdfSubmap::LoadFromStream(
     return nullptr;
   }
 
-  // Getting the transformation
+  // Getting the transformation.
   Transformation T_M_S;
   QuatTransformationProto transformation_proto = submap_proto.transform();
   conversions::transformProtoToKindr(transformation_proto, &T_M_S);
@@ -72,11 +72,11 @@ TsdfEsdfSubmap::Ptr TsdfEsdfSubmap::LoadFromStream(
   LOG(INFO) << "[ " << t.x() << ", " << t.y() << ", " << t.z() << ", " << q.w()
             << ", " << q.x() << ", " << q.y() << ", " << q.z() << " ]";
 
-  // Creating a new submap to hold the data
+  // Creating a new submap to hold the data.
   auto submap_ptr =
       std::make_shared<TsdfEsdfSubmap>(T_M_S, submap_proto.id(), config);
 
-  // Getting the tsdf blocks for this submap (the tsdf layer)
+  // Getting the tsdf blocks for this submap (the tsdf layer).
   LOG(INFO) << "Tsdf number of allocated blocks: " << submap_proto.num_blocks();
   if (!voxblox::io::LoadBlocksFromStream(
           submap_proto.num_blocks(),
@@ -86,7 +86,7 @@ TsdfEsdfSubmap::Ptr TsdfEsdfSubmap::LoadFromStream(
     LOG(ERROR) << "Could not load the tsdf blocks from stream.";
     return nullptr;
   }
-  // Getting the esdf blocks for this submap (the esdf layer)
+  // Getting the esdf blocks for this submap (the esdf layer).
   LOG(INFO) << "Esdf number of allocated blocks: "
             << submap_proto.num_esdf_blocks();
   if (!voxblox::io::LoadBlocksFromStream(


### PR DESCRIPTION
This implements a base class for the submap.
It does not assume any layer is necessary (although for everything else there should at least be a tsdf map), however, I think it is more general this way.
I did not add saving functions as virtual because then it pulls proto dependency and I did not include the loading function because that was is static anyway.

Also changing the mapping timers from int32 to int64 as @victorreijgwart suggested