### PR TITLE
Remove shared_mutex include

### DIFF
--- a/cblox_ros/include/cblox_ros/submap_server_inl.h
+++ b/cblox_ros/include/cblox_ros/submap_server_inl.h
@@ -3,7 +3,6 @@
 
 #include <memory>
 #include <mutex>
-#include <shared_mutex>
 #include <thread>
 
 #include <geometry_msgs/PoseArray.h>


### PR DESCRIPTION
shared_mutex header was added to submap_server which requires at least c++14 standard.
Since by default cblox is using c++11, and it seems that this header is unused, this PR removes it.