### PR TITLE
Submap Serialization based on const ref

### DIFF
--- a/cblox_ros/include/cblox_ros/submap_conversions.h
+++ b/cblox_ros/include/cblox_ros/submap_conversions.h
@@ -15,20 +15,17 @@ namespace cblox {
 enum class MapLayerTypes : uint8_t { kTsdf = 0u, kEsdf = 1u };
 
 template <typename SubmapType>
-std_msgs::Header generateHeaderMsg(const typename SubmapType::Ptr& submap_ptr,
+std_msgs::Header generateHeaderMsg(const SubmapType& submap,
                                    const ros::Time& timestamp);
 
 template <typename SubmapType>
-cblox_msgs::MapHeader generateSubmapHeaderMsg(
-    const typename SubmapType::Ptr& submap_ptr);
+cblox_msgs::MapHeader generateSubmapHeaderMsg(const SubmapType& submap);
 
 template <typename SubmapType>
-void serializePoseToMsg(typename SubmapType::Ptr submap_ptr,
-                        cblox_msgs::MapHeader* msg);
+void serializePoseToMsg(const SubmapType& submap, cblox_msgs::MapHeader* msg);
 
 template <typename SubmapType>
-void serializeSubmapToMsg(typename SubmapType::Ptr submap_ptr,
-                          cblox_msgs::MapLayer* msg);
+void serializeSubmapToMsg(const SubmapType& submap, cblox_msgs::MapLayer* msg);
 
 template <typename SubmapType>
 SubmapID deserializeMsgToSubmap(

--- a/cblox_ros/include/cblox_ros/submap_conversions.h
+++ b/cblox_ros/include/cblox_ros/submap_conversions.h
@@ -26,6 +26,9 @@ void serializePoseToMsg(const SubmapType& submap, cblox_msgs::MapHeader* msg);
 
 template <typename SubmapType>
 void serializeSubmapToMsg(const SubmapType& submap, cblox_msgs::MapLayer* msg);
+template <>
+void serializeSubmapToMsg<TsdfEsdfSubmap>(const TsdfEsdfSubmap& submap,
+                                          cblox_msgs::MapLayer* msg);
 
 template <typename SubmapType>
 SubmapID deserializeMsgToSubmap(
@@ -40,6 +43,9 @@ typename SubmapType::Ptr deserializeMsgToSubmapPtr(
 template <typename SubmapType>
 bool deserializeMsgToSubmapContent(cblox_msgs::MapLayer* msg_ptr,
                                    typename SubmapType::Ptr submap_ptr);
+template <>
+bool deserializeMsgToSubmapContent<TsdfEsdfSubmap>(
+    cblox_msgs::MapLayer* msg_ptr, TsdfEsdfSubmap::Ptr submap_ptr);
 
 void deserializeMsgToPose(const cblox_msgs::MapPoseUpdates& msg,
                           SubmapIdPoseMap* id_pose_map);

--- a/cblox_ros/include/cblox_ros/submap_server_inl.h
+++ b/cblox_ros/include/cblox_ros/submap_server_inl.h
@@ -518,8 +518,8 @@ void SubmapServer<SubmapType>::publishSubmap(SubmapID submap_id) const {
   CHECK(submap_collection_ptr_->exists(submap_id))
       << "[CbloxServer] Submap " << submap_id << " does not exist!";
   cblox_msgs::MapLayer submap_msg;
-  serializeSubmapToMsg<SubmapType>(
-      submap_collection_ptr_->getSubmapPtr(submap_id), &submap_msg);
+  serializeSubmapToMsg<SubmapType>(submap_collection_ptr_->getSubmap(submap_id),
+                                   &submap_msg);
   submap_pub_.publish(submap_msg);
 }
 
@@ -534,10 +534,8 @@ bool SubmapServer<SubmapType>::publishActiveSubmapCallback(
     ROS_ERROR("[CbloxServer] Active submap does not exist");
     return false;
   }
-  TsdfSubmap::Ptr submap_ptr = submap_collection_ptr_->getSubmapPtr(submap_id);
-  if (submap_ptr->getTsdfMapPtr()
-          ->getTsdfLayerPtr()
-          ->getNumberOfAllocatedBlocks() == 0) {
+  const TsdfSubmap& submap = submap_collection_ptr_->getSubmap(submap_id);
+  if (submap.getTsdfMap().getTsdfLayer().getNumberOfAllocatedBlocks() == 0) {
     if (verbose_) {
       ROS_WARN("[CbloxServer] Active submap has no allocated blocks yet");
     }
@@ -545,7 +543,7 @@ bool SubmapServer<SubmapType>::publishActiveSubmapCallback(
   }
 
   cblox_msgs::MapLayer submap_msg;
-  serializeSubmapToMsg<TsdfSubmap>(submap_ptr, &submap_msg);
+  serializeSubmapToMsg<TsdfSubmap>(submap, &submap_msg);
   response.submap_msg = submap_msg;
   return true;
 }
@@ -575,10 +573,9 @@ void SubmapServer<SubmapType>::publishSubmapPoses() const {
   pose_msg.header.frame_id = world_frame_;
   pose_msg.header.stamp = ros::Time::now();
   for (SubmapID submap_id : submap_collection_ptr_->getIDs()) {
-    typename SubmapType::Ptr submap_ptr =
-        submap_collection_ptr_->getSubmapPtr(submap_id);
+    const SubmapType& submap = submap_collection_ptr_->getSubmap(submap_id);
     pose_msg.map_headers.emplace_back(
-        generateSubmapHeaderMsg<SubmapType>(submap_ptr));
+        generateSubmapHeaderMsg<SubmapType>(submap));
   }
   pose_pub_.publish(pose_msg);
 }

--- a/cblox_ros/src/submap_conversions.cc
+++ b/cblox_ros/src/submap_conversions.cc
@@ -7,14 +7,14 @@
 namespace cblox {
 
 template <>
-void serializeSubmapToMsg<TsdfEsdfSubmap>(TsdfEsdfSubmap::Ptr submap_ptr,
+void serializeSubmapToMsg<TsdfEsdfSubmap>(const TsdfEsdfSubmap& submap,
                                           cblox_msgs::MapLayer* msg) {
-  serializeSubmapToMsg<TsdfSubmap>(submap_ptr, msg);
+  serializeSubmapToMsg<TsdfSubmap>(submap, msg);
 
   // set type to ESDF
   msg->type = static_cast<uint8_t>(MapLayerTypes::kEsdf);
   voxblox::serializeLayerAsMsg<EsdfVoxel>(
-      submap_ptr->getEsdfMapPtr()->getEsdfLayer(), false, &msg->esdf_layer);
+      submap.getEsdfMap().getEsdfLayer(), false, &msg->esdf_layer);
   msg->esdf_layer.action =
       static_cast<uint8_t>(voxblox::MapDerializationAction::kReset);
 }


### PR DESCRIPTION
Serializing submaps to messages based on a const ref instead of a shared ptr.
Added declaration of template specialization in the header file.