### PR TITLE
Mainly remove assumption that Submap needs to contain a TsdfMap

### DIFF
--- a/cblox/include/cblox/core/submap.h
+++ b/cblox/include/cblox/core/submap.h
@@ -2,6 +2,7 @@
 #define CBLOX_CORE_SUBMAP_H_
 
 #include <mutex>
+#include <utility>
 
 #include "cblox/core/common.h"
 
@@ -31,6 +32,15 @@ class Submap {
 
   inline SubmapID getID() const { return submap_id_; }
 
+  // Set interval in which submap was actively mapping.
+  inline void startMappingTime(int64_t time) { mapping_interval_.first = time; }
+  inline void stopMappingTime(int64_t time) { mapping_interval_.second = time; }
+
+  // Access mapping interval.
+  inline const std::pair<int64_t, int64_t>& getMappingInterval() const {
+    return mapping_interval_;
+  }
+
   virtual size_t getNumberOfAllocatedBlocks() const = 0;
 
   virtual size_t getMemorySize() const = 0;
@@ -38,6 +48,14 @@ class Submap {
   virtual void finishSubmap() = 0;
 
   virtual void prepareForPublish() = 0;
+
+  // NOTE(ntonci): This assumes that all derived submap types will have at least
+  // TSDF Layer.
+  virtual voxblox::Layer<TsdfVoxel>* getTsdfLayerPtr() = 0;
+  virtual const voxblox::Layer<TsdfVoxel>& getTsdfLayer() const = 0;
+
+  virtual FloatingPoint block_size() const = 0;
+  virtual FloatingPoint voxel_size() const = 0;
 
   /*
   // Note(ntonci): In order to provide saving/loading functionality to the
@@ -58,6 +76,7 @@ class Submap {
  protected:
   const SubmapID submap_id_;
   Transformation T_M_S_;
+  std::pair<int64_t, int64_t> mapping_interval_;
 
  private:
   mutable std::mutex transformation_mutex_;

--- a/cblox/include/cblox/core/submap_collection.h
+++ b/cblox/include/cblox/core/submap_collection.h
@@ -16,7 +16,7 @@ namespace cblox {
 class SubmapCollectionInterface {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  
+
   typedef std::shared_ptr<SubmapCollectionInterface> Ptr;
   typedef std::shared_ptr<const SubmapCollectionInterface> ConstPtr;
 
@@ -31,9 +31,10 @@ class SubmapCollectionInterface {
   virtual bool getSubmapPose(const SubmapID submap_id,
                              Transformation* pose_ptr) const = 0;
 
-  virtual TsdfMap::Ptr getActiveTsdfMapPtr() = 0;
-  virtual const TsdfMap& getActiveTsdfMap() const = 0;
-  virtual TsdfMap::Ptr getTsdfMapPtr(const SubmapID submap_id) = 0;
+  virtual voxblox::Layer<TsdfVoxel>* getActiveTsdfLayerPtr() = 0;
+  virtual voxblox::Layer<TsdfVoxel>* getTsdfLayerPtr(
+      const SubmapID submap_id) = 0;
+  virtual const voxblox::Layer<TsdfVoxel>& getActiveTsdfLayer() const = 0;
 
   virtual bool empty() const = 0;
   virtual size_t size() const = 0;
@@ -102,11 +103,11 @@ class SubmapCollection : public SubmapCollectionInterface {
   const Transformation& getActiveSubmapPose() const;
   SubmapID getActiveSubmapID() const;
 
-  // Access the tsdf_map member of the active submap
-  TsdfMap::Ptr getActiveTsdfMapPtr();
-  const TsdfMap& getActiveTsdfMap() const;
-  // Access the tsdf_map member of any submap
-  virtual TsdfMap::Ptr getTsdfMapPtr(const SubmapID submap_id);
+  // Access the tsdf_layer member of the active submap
+  voxblox::Layer<TsdfVoxel>* getActiveTsdfLayerPtr();
+  const voxblox::Layer<TsdfVoxel>& getActiveTsdfLayer() const;
+  // Access the tsdf_layer member of any submap
+  voxblox::Layer<TsdfVoxel>* getTsdfLayerPtr(const SubmapID submap_id);
 
   // Activate a submap
   // NOTE(alexmillane): Note that creating a new submap automatically activates
@@ -162,6 +163,11 @@ class SubmapCollection : public SubmapCollectionInterface {
 
   // Gets the combined memory size of the layers in this collection.
   size_t getMemorySize() const;
+
+  inline const std::map<SubmapID, typename SubmapType::Ptr>& getIdToSubmap()
+      const {
+    return id_to_submap_;
+  }
 
   // Loading from file
   static bool LoadFromFile(

--- a/cblox/include/cblox/integrator/tsdf_submap_collection_integrator.h
+++ b/cblox/include/cblox/integrator/tsdf_submap_collection_integrator.h
@@ -34,10 +34,10 @@ class TsdfSubmapCollectionIntegrator {
 
  private:
   // Initializes the integrator
-  void initializeIntegrator(const TsdfMap::Ptr& tsdf_map_ptr);
+  void initializeIntegrator(voxblox::Layer<TsdfVoxel>* tsdf_layer_ptr);
 
   // Changes the integration target the latest submap in the collection.
-  void updateIntegratorTarget(const TsdfMap::Ptr& tsdf_map_ptr);
+  void updateIntegratorTarget(voxblox::Layer<TsdfVoxel>* tsdf_layer_ptr);
 
   // Gets the submap relative pose
   // NOTE(alexmilane): T_G_S - Transformation between camera frame (C) and

--- a/cblox/include/cblox/mesh/submap_mesher_inl.h
+++ b/cblox/include/cblox/mesh/submap_mesher_inl.h
@@ -57,14 +57,11 @@ void SubmapMesher::generateSeparatedMeshLayers(
     CHECK_NOTNULL(sub_map_ptr.get());
     LOG(INFO) << "Generating mesh for submap number #" << mesh_index;
     mesh_index++;
-    // Getting the TSDF data
-    const TsdfMap& tsdf_map = sub_map_ptr->getTsdfMap();
     // Creating a mesh layer to hold the mesh fragment
-    MeshLayer::Ptr mesh_layer_ptr(
-        new MeshLayer(sub_map_ptr->getTsdfMap().block_size()));
+    MeshLayer::Ptr mesh_layer_ptr(new MeshLayer(sub_map_ptr->block_size()));
     // Generating the mesh
     MeshIntegrator<TsdfVoxel> mesh_integrator(
-        mesh_config_, tsdf_map.getTsdfLayer(), mesh_layer_ptr.get());
+        mesh_config_, sub_map_ptr->getTsdfLayer(), mesh_layer_ptr.get());
     constexpr bool only_mesh_updated_blocks = false;
     constexpr bool clear_updated_flag = false;
     mesh_integrator.generateMesh(only_mesh_updated_blocks, clear_updated_flag);
@@ -78,7 +75,7 @@ void SubmapMesher::generateMeshInGlobalFrame(const SubmapType& submap,
                                              MeshLayer* mesh_layer_G_ptr) {
   CHECK_NOTNULL(mesh_layer_G_ptr);
   // Mesh in submap frame
-  MeshLayer mesh_layer_S(submap.getTsdfMap().block_size());
+  MeshLayer mesh_layer_S(submap.block_size());
   generateMeshInSubmapFrame(submap, &mesh_layer_S);
   // To world frame
   const Transformation& T_G_S = submap.getPose();
@@ -89,11 +86,9 @@ template <typename SubmapType>
 void SubmapMesher::generateMeshInSubmapFrame(const SubmapType& submap,
                                              MeshLayer* mesh_layer_S_ptr) {
   CHECK_NOTNULL(mesh_layer_S_ptr);
-  // Getting the TSDF data
-  const TsdfMap& tsdf_map = submap.getTsdfMap();
   // Generating the mesh
-  MeshIntegrator<TsdfVoxel> mesh_integrator(
-      mesh_config_, tsdf_map.getTsdfLayer(), mesh_layer_S_ptr);
+  MeshIntegrator<TsdfVoxel> mesh_integrator(mesh_config_, submap.getTsdfLayer(),
+                                            mesh_layer_S_ptr);
   constexpr bool only_mesh_updated_blocks = false;
   constexpr bool clear_updated_flag = false;
   mesh_integrator.generateMesh(only_mesh_updated_blocks, clear_updated_flag);

--- a/cblox/src/core/tsdf_esdf_submap.cpp
+++ b/cblox/src/core/tsdf_esdf_submap.cpp
@@ -1,4 +1,7 @@
 #include "cblox/core/tsdf_esdf_submap.h"
+
+#include <memory>
+
 #include "cblox/utils/quat_transformation_protobuf_utils.h"
 
 namespace cblox {
@@ -81,8 +84,7 @@ TsdfEsdfSubmap::Ptr TsdfEsdfSubmap::LoadFromStream(
   if (!voxblox::io::LoadBlocksFromStream(
           submap_proto.num_blocks(),
           Layer<TsdfVoxel>::BlockMergingStrategy::kReplace, proto_file_ptr,
-          submap_ptr->getTsdfMapPtr()->getTsdfLayerPtr(),
-          tmp_byte_offset_ptr)) {
+          submap_ptr->getTsdfLayerPtr(), tmp_byte_offset_ptr)) {
     LOG(ERROR) << "Could not load the tsdf blocks from stream.";
     return nullptr;
   }
@@ -96,8 +98,7 @@ TsdfEsdfSubmap::Ptr TsdfEsdfSubmap::LoadFromStream(
   if (!voxblox::io::LoadBlocksFromStream(
           submap_proto.num_esdf_blocks(),
           Layer<EsdfVoxel>::BlockMergingStrategy::kReplace, proto_file_ptr,
-          submap_ptr->getEsdfMapPtr()->getEsdfLayerPtr(),
-          tmp_byte_offset_ptr)) {
+          submap_ptr->getEsdfLayerPtr(), tmp_byte_offset_ptr)) {
     LOG(ERROR) << "Could not load the esdf blocks from stream.";
     return nullptr;
   }

--- a/cblox/src/core/tsdf_submap.cpp
+++ b/cblox/src/core/tsdf_submap.cpp
@@ -1,5 +1,7 @@
 #include "cblox/core/tsdf_submap.h"
 
+#include <memory>
+
 #include "cblox/utils/quat_transformation_protobuf_utils.h"
 
 namespace cblox {
@@ -84,8 +86,7 @@ TsdfSubmap::Ptr TsdfSubmap::LoadFromStream(const Config& config,
   if (!voxblox::io::LoadBlocksFromStream(
           submap_proto.num_blocks(),
           Layer<TsdfVoxel>::BlockMergingStrategy::kReplace, proto_file_ptr,
-          submap_ptr->getTsdfMapPtr()->getTsdfLayerPtr(),
-          tmp_byte_offset_ptr)) {
+          submap_ptr->getTsdfLayerPtr(), tmp_byte_offset_ptr)) {
     LOG(ERROR) << "Could not load the tsdf blocks from stream.";
     return nullptr;
   }

--- a/cblox/src/integrator/tsdf_submap_collection_integrator.cpp
+++ b/cblox/src/integrator/tsdf_submap_collection_integrator.cpp
@@ -25,27 +25,27 @@ void TsdfSubmapCollectionIntegrator::switchToActiveSubmap() {
   //                    that between new submap creation and activation the
   //                    integrator wont be affecting the latest submap in the
   //                    collection.
-  updateIntegratorTarget(tsdf_submap_collection_ptr_->getActiveTsdfMapPtr());
+  updateIntegratorTarget(tsdf_submap_collection_ptr_->getActiveTsdfLayerPtr());
   T_G_S_active_ = tsdf_submap_collection_ptr_->getActiveSubmapPose();
 }
 
 void TsdfSubmapCollectionIntegrator::initializeIntegrator(
-    const TsdfMap::Ptr& tsdf_map_ptr) {
-  CHECK(tsdf_map_ptr);
+    voxblox::Layer<TsdfVoxel>* tsdf_layer_ptr) {
+  CHECK(tsdf_layer_ptr);
   // Creating with the voxblox provided factory
   tsdf_integrator_ = voxblox::TsdfIntegratorFactory::create(
-      method_, tsdf_integrator_config_, tsdf_map_ptr->getTsdfLayerPtr());
+      method_, tsdf_integrator_config_, tsdf_layer_ptr);
 }
 
 void TsdfSubmapCollectionIntegrator::updateIntegratorTarget(
-    const TsdfMap::Ptr& tsdf_map_ptr) {
-  CHECK(tsdf_map_ptr);
+    voxblox::Layer<TsdfVoxel>* tsdf_layer_ptr) {
+  CHECK(tsdf_layer_ptr);
   // Creating the integrator if not yet created.
   // Otherwise, changing the integration target.
   if (tsdf_integrator_ == nullptr) {
-    initializeIntegrator(tsdf_map_ptr);
+    initializeIntegrator(tsdf_layer_ptr);
   } else {
-    tsdf_integrator_->setLayer(tsdf_map_ptr->getTsdfLayerPtr());
+    tsdf_integrator_->setLayer(tsdf_layer_ptr);
   }
 }
 

--- a/cblox_ros/include/cblox_ros/submap_conversions.h
+++ b/cblox_ros/include/cblox_ros/submap_conversions.h
@@ -1,5 +1,5 @@
-#ifndef CBLOX_ROS_SUBMAP_CONVERSIONS_H
-#define CBLOX_ROS_SUBMAP_CONVERSIONS_H
+#ifndef CBLOX_ROS_SUBMAP_CONVERSIONS_H_
+#define CBLOX_ROS_SUBMAP_CONVERSIONS_H_
 
 #include <geometry_msgs/Pose.h>
 #include <minkindr_conversions/kindr_msg.h>
@@ -56,6 +56,6 @@ Transformation deserializeMsgToSubmapPose(cblox_msgs::MapLayer* msg_ptr);
 
 }  // namespace cblox
 
-#endif  // CBLOX_ROS_SUBMAP_CONVERSIONS_H
+#endif  // CBLOX_ROS_SUBMAP_CONVERSIONS_H_
 
 #include "cblox_ros/submap_conversions_inl.h"

--- a/cblox_ros/include/cblox_ros/submap_conversions_inl.h
+++ b/cblox_ros/include/cblox_ros/submap_conversions_inl.h
@@ -1,5 +1,5 @@
-#ifndef CBLOX_ROS_SUBMAP_CONVERSIONS_INL_H
-#define CBLOX_ROS_SUBMAP_CONVERSIONS_INL_H
+#ifndef CBLOX_ROS_SUBMAP_CONVERSIONS_INL_H_
+#define CBLOX_ROS_SUBMAP_CONVERSIONS_INL_H_
 
 #include <voxblox_ros/conversions.h>
 
@@ -18,8 +18,7 @@ std_msgs::Header generateHeaderMsg(const SubmapType& submap,
 }
 
 template <typename SubmapType>
-cblox_msgs::MapHeader generateSubmapHeaderMsg(
-    const SubmapType& submap) {
+cblox_msgs::MapHeader generateSubmapHeaderMsg(const SubmapType& submap) {
   // Set the submap ID and type.
   cblox_msgs::MapHeader submap_header;
   submap_header.id = submap.getID();
@@ -53,8 +52,7 @@ void serializePoseToMsg(const SubmapType& submap,
 
 // Note: Assumes that SubmapType contains a tsdf map.
 template <typename SubmapType>
-void serializeSubmapToMsg(const SubmapType& submap,
-                          cblox_msgs::MapLayer* msg) {
+void serializeSubmapToMsg(const SubmapType& submap, cblox_msgs::MapLayer* msg) {
   CHECK_NOTNULL(msg);
 
   ros::Time timestamp = ros::Time::now();
@@ -66,8 +64,8 @@ void serializeSubmapToMsg(const SubmapType& submap,
   msg->type = static_cast<uint8_t>(MapLayerTypes::kTsdf);
 
   // Fill in TSDF layer.
-  voxblox::serializeLayerAsMsg<voxblox::TsdfVoxel>(
-      submap.getTsdfMap().getTsdfLayer(), false, &msg->tsdf_layer);
+  voxblox::serializeLayerAsMsg<voxblox::TsdfVoxel>(submap.getTsdfLayer(), false,
+                                                   &msg->tsdf_layer);
   msg->tsdf_layer.action =
       static_cast<uint8_t>(voxblox::MapDerializationAction::kReset);
 }
@@ -95,8 +93,8 @@ bool deserializeMsgToSubmapContent(cblox_msgs::MapLayer* msg_ptr,
   submap_ptr->startMappingTime(msg_ptr->map_header.start_time.toNSec());
   submap_ptr->stopMappingTime(msg_ptr->map_header.end_time.toNSec());
 
-  return voxblox::deserializeMsgToLayer(
-      msg_ptr->tsdf_layer, submap_ptr->getTsdfMapPtr()->getTsdfLayerPtr());
+  return voxblox::deserializeMsgToLayer(msg_ptr->tsdf_layer,
+                                        submap_ptr->getTsdfLayerPtr());
 }
 
 template <typename SubmapType>
@@ -116,4 +114,4 @@ SubmapID deserializeMsgToSubmap(
 }
 
 }  // namespace cblox
-#endif  // CBLOX_ROS_SUBMAP_CONVERSIONS_INL_H
+#endif  // CBLOX_ROS_SUBMAP_CONVERSIONS_INL_H_

--- a/cblox_ros/include/cblox_ros/submap_server.h
+++ b/cblox_ros/include/cblox_ros/submap_server.h
@@ -101,7 +101,7 @@ class SubmapServer {
   inline void setVerbose(bool verbose) {
     verbose_ = verbose;
     active_submap_visualizer_ptr_->setVerbose(verbose_);
-  };
+  }
 
  protected:
   // Gets parameters
@@ -130,12 +130,12 @@ class SubmapServer {
 
   // Initializes the map
   bool mapIntialized() const { return !submap_collection_ptr_->empty(); }
-  void intializeMap(const Transformation& T_G_C);
+  void intializeMap(const Transformation& T_G_C, const ros::Time& timestamp);
 
   // Submap creation
   bool newSubmapRequired() const;
   void createNewSubmap(const Transformation& T_G_C, const ros::Time& timestamp);
-  void finishSubmap(const SubmapID submap_id);
+  void finishSubmap(const SubmapID submap_id, const ros::Time& timestamp);
 
   // Submap pose updates
   bool publishSubmapPosesCallback(std_srvs::EmptyRequest&,
@@ -147,8 +147,9 @@ class SubmapServer {
   // Submap publishing
   void publishSubmap(SubmapID submap_id) const;
   void publishWholeMap() const;
-  bool publishActiveSubmapCallback(cblox_msgs::SubmapSrvRequest& request,
-                                   cblox_msgs::SubmapSrvResponse& response);
+  bool publishActiveSubmapCallback(
+      cblox_msgs::SubmapSrvRequest& request,     // NOLINT
+      cblox_msgs::SubmapSrvResponse& response);  // NOLINT
   bool publishActiveSubmap();
 
   // visualization
@@ -234,6 +235,6 @@ class SubmapServer {
 
 }  // namespace cblox
 
-#endif  // CBLOX_ROS_SUBMAP_SERVER__H_
+#endif  // CBLOX_ROS_SUBMAP_SERVER_H_
 
 #include "cblox_ros/submap_server_inl.h"

--- a/cblox_ros/src/active_submap_visualizer.cc
+++ b/cblox_ros/src/active_submap_visualizer.cc
@@ -57,9 +57,7 @@ void ActiveSubmapVisualizer::updateIntegrator() {
   // New integrator operating on the mesh.
   active_submap_mesh_integrator_ptr_.reset(
       new voxblox::MeshIntegrator<TsdfVoxel>(
-          mesh_config_,
-          tsdf_submap_collection_ptr_->getTsdfMapPtr(active_submap_id_)
-              ->getTsdfLayerPtr(),
+          mesh_config_, tsdf_submap_collection_ptr_->getActiveTsdfLayerPtr(),
           active_submap_mesh_layer_ptr_.get()));
 }
 

--- a/cblox_ros/src/submap_conversions.cc
+++ b/cblox_ros/src/submap_conversions.cc
@@ -13,8 +13,8 @@ void serializeSubmapToMsg<TsdfEsdfSubmap>(const TsdfEsdfSubmap& submap,
 
   // set type to ESDF
   msg->type = static_cast<uint8_t>(MapLayerTypes::kEsdf);
-  voxblox::serializeLayerAsMsg<EsdfVoxel>(
-      submap.getEsdfMap().getEsdfLayer(), false, &msg->esdf_layer);
+  voxblox::serializeLayerAsMsg<EsdfVoxel>(submap.getEsdfLayer(), false,
+                                          &msg->esdf_layer);
   msg->esdf_layer.action =
       static_cast<uint8_t>(voxblox::MapDerializationAction::kReset);
 }
@@ -58,9 +58,9 @@ bool deserializeMsgToSubmapContent<TsdfEsdfSubmap>(
   }
 
   bool esdf_success = voxblox::deserializeMsgToLayer(
-      msg_ptr->esdf_layer, submap_ptr->getEsdfMapPtr()->getEsdfLayerPtr());
+      msg_ptr->esdf_layer, submap_ptr->getEsdfLayerPtr());
   // generate ESDF layer if necessary
-  if (tsdf_success and !esdf_success) {
+  if (tsdf_success && !esdf_success) {
     submap_ptr->generateEsdf();
   }
   return true;

--- a/cblox_ros/src/submap_server.cc
+++ b/cblox_ros/src/submap_server.cc
@@ -27,7 +27,7 @@ void SubmapServer<TsdfSubmap>::visualizeSlice(const SubmapID submap_id) const {
       submap_collection_ptr_->getSubmapPtr(submap_id)->getPose();
   vertex_marker.pose.orientation.w = 1.0;
   vertex_marker.scale.x =
-      submap_collection_ptr_->getActiveTsdfMapPtr()->voxel_size();
+      submap_collection_ptr_->getActiveSubmapPtr()->voxel_size();
   vertex_marker.scale.y = vertex_marker.scale.x;
   vertex_marker.scale.z = vertex_marker.scale.x;
   geometry_msgs::Point point_msg;
@@ -39,8 +39,7 @@ void SubmapServer<TsdfSubmap>::visualizeSlice(const SubmapID submap_id) const {
 
   const float max_dist = truncation_distance_;
   TsdfSubmap::Ptr submap_ptr = submap_collection_ptr_->getSubmapPtr(submap_id);
-  voxblox::Layer<voxblox::TsdfVoxel>* layer =
-      submap_ptr->getTsdfMapPtr()->getTsdfLayerPtr();
+  voxblox::Layer<voxblox::TsdfVoxel>* layer = submap_ptr->getTsdfLayerPtr();
   voxblox::BlockIndexList block_list;
   layer->getAllAllocatedBlocks(&block_list);
   int block_num = 0;
@@ -68,7 +67,7 @@ void SubmapServer<TsdfSubmap>::visualizeSlice(const SubmapID submap_id) const {
       }
 
       if (std::abs(position.z() - slice_height_) <
-          submap_ptr->getTsdfMapPtr()->voxel_size() / 2) {
+          submap_ptr->voxel_size() / 2) {
         vertex_marker.id =
             block_num +
             voxel_id * std::pow(10, std::round(std::log10(block_list.size())));


### PR DESCRIPTION
Summary:
- Move mapping time methods to base class.
- Update all TsdfMap/EsdfMap getters to TsdfLayer/EsdfLayer getters.
- Add id_to_submap getter.
- Update getNumberOfAllocatedBlocks and getMemorySize virtual methods for TsdfEsdfSubmap.

The main idea was to be able to support SubmapTypes that do not contain TsdfMap (since in all the cases here we actually just want the layer). This might have some minor implications on Voxgraph (@victorreijgwart).
Unfortunately, I wasn't able to thoroughly test this so it would be good if you could check it quickly or point me to a bag file that is relevant to properly test this.
