### PR TITLE
Bump to c++14 as required by PCL on 20.04

### DIFF
--- a/cblox/CMakeLists.txt
+++ b/cblox/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.0)
 project(cblox)
 
-add_definitions(-std=c++11)
+add_definitions(-std=c++14)
 
 find_package(catkin_simple REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)

--- a/cblox_ros/CMakeLists.txt
+++ b/cblox_ros/CMakeLists.txt
@@ -4,7 +4,7 @@ project(cblox_ros)
 find_package(catkin_simple REQUIRED)
 catkin_simple(ALL_DEPS_REQUIRED)
 
-add_definitions(-std=c++11 -Wall -Wextra)
+add_definitions(-std=c++14 -Wall -Wextra)
 
 #############
 # LIBRARIES #


### PR DESCRIPTION
Fixes the build on 20.04.

See ethz-asl/voxblox#370

